### PR TITLE
Kjører useEffect en gang

### DIFF
--- a/src/pages/vedtak-side/vedtak-side.tsx
+++ b/src/pages/vedtak-side/vedtak-side.tsx
@@ -73,7 +73,7 @@ const VedtakSide = () => {
             merkVedtakSomLest().catch(r => logger.error('Feil ved markering av vedtak som lest async', r))
         }
         // eslint-disable-next-line
-    }, [ valgtVedtak, inntektsmeldinger ])
+    }, [])
 
     if (valgtVedtak === undefined) return null
 


### PR DESCRIPTION
Direkte åpning av vedtak førte til at useEffect kjørte 2 ganger før async kall var ferdig