### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:a6c0e95f

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:f912a7599e5338df6527a669def29bddc9469fdac9ab22c4cc9282c1b64c868b
+FROM gcr.io/distroless/nodejs20-debian12@sha256:a6c0e95f6f70fb21586757a846d8b8d287609f2414bcc2399895adb055768648
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Fra flex-cli