### PR TITLE
Disabler autoinstrumentering grunnet produksjon problemer

### DIFF
--- a/nais/app/naiserator.yaml
+++ b/nais/app/naiserator.yaml
@@ -56,7 +56,7 @@ spec:
   {{/each}}
   observability:
     autoInstrumentation:
-      enabled: true
+      enabled: false
       runtime: nodejs
     logging:
       destinations:


### PR DESCRIPTION
Invalid JWT token found (cause: Client network socket disconnected before secure TLS connection was established, redirecting to login.: Client network socket disconnected before secure TLS connection was established