### PR TITLE
Samler overskrifter med unik tekst per bruker i amplitude

### DIFF
--- a/src/components/expansioncard/vedtak-expansion-card.tsx
+++ b/src/components/expansioncard/vedtak-expansion-card.tsx
@@ -40,7 +40,7 @@ export const VedtakExpansionCard = ({
         const ryddetTittel = cleanLogEventTittel(tittel)
         const newOpen = !apne
         logEvent(newOpen ? 'expansioncard åpnet' : 'expansioncard lukket', {
-            tittel : ryddetTittel,
+            tittel: ryddetTittel,
             undertittel: undertittel || '',
             component: componentName || 'VedtakExpansionCard',
         })


### PR DESCRIPTION
De deler nå tittel, noe som gjør at du ikke får oppføringer per antall sykepengedager
