### PR TITLE
Oppdater tekst for ForeldetDag (Søkt for sent)

### DIFF
--- a/playwright/utbetalingsoversikt.spec.ts
+++ b/playwright/utbetalingsoversikt.spec.ts
@@ -116,7 +116,7 @@ test.describe('Utbetalingsoversikt', () => {
                 },
                 {
                     key: 'ForeldetDag',
-                    tekst: 'Du må søke om sykepenger senest tre måneder etter den siste måneden du var syk.',
+                    tekst: 'Søknaden kom inn etter fristen. Nav kan gi sykepenger for opptil tre måneder før den måneden du sendte søknaden.',
                 },
                 {
                     key: 'Ventetidsdag',

--- a/src/components/vedtak-side/utbetaling/utbetaling-tekster.ts
+++ b/src/components/vedtak-side/utbetaling/utbetaling-tekster.ts
@@ -83,7 +83,7 @@ const UtbetalingTekster = {
     'utbetaling.tabell.label.Permisjonsdag':
         'Du får ikke sykepenger for dager der du eller arbeidsgiveren din har oppgitt at du hadde permisjon. Se <a href="https://lovdata.no/nav/folketrygdloven/kap8/%C2%A78-17" target="_blank">folketrygdloven § 8-17</a>, andre avsnitt.',
     'utbetaling.tabell.label.ForeldetDag':
-        'Du må søke om sykepenger senest tre måneder etter den siste måneden du var syk. Vi har vurdert at du ikke oppfyller unntaksregelen som gir mulighet til å søke opptil tre år tilbake i tid. Se <a href="https://lovdata.no/nav/folketrygdloven/kap22/%C2%A722-13" target="_blank">folketrygdloven § 22-13</a>, tredje og sjuende avsnitt.',
+        'Søknaden kom inn etter fristen. Nav kan gi sykepenger for opptil tre måneder før den måneden du sendte søknaden. I særlige tilfeller kan det gjøres unntak, slik at sykepenger kan gis opptil tre år tilbake i tid. Vi finner ikke grunnlag for unntak i denne saken. Du får derfor ikke sykepenger for denne dagen (<a href="https://lovdata.no/nav/folketrygdloven/kap22/%C2%A722-13" target="_blank">folketrygdloven § 22-13</a>, tredje og sjuende avsnitt).',
     'utbetaling.tabell.label.Ventetidsdag':
         'Du kan få sykepenger fra og med 17. dagen i sykefraværet ditt. De første 16 dagene teller fra du får en sykmelding, eller gir beskjed til Nav om at du er syk og ikke kan jobbe. Se <a href="https://lovdata.no/nav/folketrygdloven/kap22/%C2%A78-34" target="_blank">folketrygdloven § 8-34</a>, andre avsnitt.',
     'utbetaling.tabell.label.UkjentDag':


### PR DESCRIPTION
## Bakgrunn

Fikset etter tilbakemelding fra saksbehandler via Flexjar.

## Endring

Teksten den sykmeldte ser ved avslag pga. for sent fremsatt krav var ikke presis:

> ~~Du må søke om sykepenger senest tre måneder etter den siste måneden du var syk.~~

Det er ikke siste måneden du var syk som er relevant, men måneden søknaden ble sendt inn.

**Ny tekst:**

> Søknaden kom inn etter fristen. Nav kan gi sykepenger for opptil tre måneder før den måneden du sendte søknaden. I særlige tilfeller kan det gjøres unntak, slik at sykepenger kan gis opptil tre år tilbake i tid. Vi finner ikke grunnlag for unntak i denne saken. Du får derfor ikke sykepenger for denne dagen (folketrygdloven § 22-13, tredje og sjuende avsnitt).

## Filer

- `src/components/vedtak-side/utbetaling/utbetaling-tekster.ts` – oppdatert `ForeldetDag`-tekst
- `playwright/utbetalingsoversikt.spec.ts` – oppdatert tilhørende playwright-test