### PR TITLE
fix: parse datostrenger som lokal tid for å unngå UTC-tidssoneforskyvning

### DIFF
--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -1,0 +1,36 @@
+import { test as base, expect } from '@playwright/test'
+
+import { kunDirekte } from '../src/data/testdata/data/vedtak/kunDirekte'
+
+const timezones = ['Europe/Oslo', 'America/New_York', 'UTC']
+
+for (const timezoneId of timezones) {
+    base.describe(`Datovisning i tidssone ${timezoneId}`, () => {
+        base(`viser korrekte datoer på vedtakssiden`, async ({ browser }) => {
+            const context = await browser.newContext({ timezoneId })
+            const page = await context.newPage()
+
+            await page.goto(`/syk/sykepenger?testperson=kun-direkte`)
+            await expect(page.getByRole('link', { name: /Sykmeldt fra /i })).toHaveCount(1)
+
+            const vedtakLink = page.locator(`a[href*="${kunDirekte.id}"]`).first()
+            await expect(vedtakLink).toBeVisible()
+            await vedtakLink.click()
+
+            // Verifiser perioden (fom: '2021-02-08', tom: '2021-02-21')
+            // Bruker tilLesbarPeriodeMedArstall som var sårbar for tidssone-bug
+            await expect(page.getByText('8. – 21. februar 2021')).toBeVisible()
+
+            // Verifiser "per {dato}" i sykepengedager-panelet
+            // Bruker tilLesbarDatoMedArstall direkte med dato-streng tom='2021-02-21'
+            await page.getByText('Gjenstående sykepengedager').click({ force: true })
+            await expect(page.getByText('per 21. februar 2021')).toBeVisible()
+
+            // Verifiser behandlingsdato (vedtakFattetTidspunkt: '2021-02-21')
+            // Bruker tilLesbarDatoMedArstall via dayjs().toDate()
+            await expect(page.getByText('Søknaden ble behandlet 21. februar 2021')).toBeVisible()
+
+            await context.close()
+        })
+    })
+}

--- a/src/utils/dato-utils.test.ts
+++ b/src/utils/dato-utils.test.ts
@@ -44,13 +44,13 @@ describe('tilLesbarPeriodeMedArstall', () => {
 
 describe('erHelg', () => {
     it('returnerer true for lørdag', () => {
-        expect(erHelg(new Date('2025-12-06'))).toBe(true)
+        expect(erHelg(new Date(2025, 11, 6))).toBe(true)
     })
     it('returnerer true for søndag', () => {
-        expect(erHelg(new Date('2025-12-07'))).toBe(true)
+        expect(erHelg(new Date(2025, 11, 7))).toBe(true)
     })
     it('returnerer false for hverdag', () => {
-        expect(erHelg(new Date('2025-12-02'))).toBe(false)
+        expect(erHelg(new Date(2025, 11, 2))).toBe(false)
     })
 })
 

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -17,8 +17,8 @@ const maaneder = [
 ]
 const SKILLETEGN_PERIODE = '–'
 
-// new Date('YYYY-MM-DD') parses as UTC midnight, which shifts the date back by one day
-// for users in timezones west of UTC. Parse date-only strings as local midnight instead.
+// new Date('YYYY-MM-DD') tolkes som UTC midnatt, som forskyver datoen én dag tilbake
+// for brukere i tidssoner vest for UTC. Parser dato-strenger som lokal midnatt i stedet.
 function parseLocalDate(datoArg: Date | string): Date {
     if (datoArg instanceof Date) return datoArg
     const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(datoArg))
@@ -28,7 +28,7 @@ function parseLocalDate(datoArg: Date | string): Date {
     return new Date(String(datoArg))
 }
 
-export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
+export const tilLesbarDatoUtenAarstall = (datoArg: Date | string | undefined | null): string => {
     if (datoArg) {
         const dato = parseLocalDate(datoArg)
         const dag = dato.getDate()
@@ -39,13 +39,13 @@ export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
     return ''
 }
 
-export const tilLesbarDatoMedArstall = (datoArg: any) => {
+export const tilLesbarDatoMedArstall = (datoArg: Date | string | undefined | null): string | undefined => {
     if (!datoArg) return undefined
     const dato = parseLocalDate(datoArg)
     return `${tilLesbarDatoUtenAarstall(dato)} ${dato.getFullYear()}`
 }
 
-export const tilLesbarPeriodeMedArstall = (fomArg: any, tomArg: any) => {
+export const tilLesbarPeriodeMedArstall = (fomArg: Date | string, tomArg: Date | string) => {
     const fom = parseLocalDate(fomArg)
     const tom = parseLocalDate(tomArg)
     const erSammeAar = fom.getFullYear() === tom.getFullYear()

--- a/src/utils/dato-utils.ts
+++ b/src/utils/dato-utils.ts
@@ -17,9 +17,20 @@ const maaneder = [
 ]
 const SKILLETEGN_PERIODE = '–'
 
+// new Date('YYYY-MM-DD') parses as UTC midnight, which shifts the date back by one day
+// for users in timezones west of UTC. Parse date-only strings as local midnight instead.
+function parseLocalDate(datoArg: Date | string): Date {
+    if (datoArg instanceof Date) return datoArg
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(datoArg))
+    if (match) {
+        return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+    }
+    return new Date(String(datoArg))
+}
+
 export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
     if (datoArg) {
-        const dato = new Date(datoArg)
+        const dato = parseLocalDate(datoArg)
         const dag = dato.getDate()
         const manedIndex = dato.getMonth()
         const maned = maaneder[manedIndex]
@@ -29,12 +40,14 @@ export const tilLesbarDatoUtenAarstall = (datoArg: any): string => {
 }
 
 export const tilLesbarDatoMedArstall = (datoArg: any) => {
-    return datoArg ? `${tilLesbarDatoUtenAarstall(new Date(datoArg))} ${new Date(datoArg).getFullYear()}` : undefined
+    if (!datoArg) return undefined
+    const dato = parseLocalDate(datoArg)
+    return `${tilLesbarDatoUtenAarstall(dato)} ${dato.getFullYear()}`
 }
 
 export const tilLesbarPeriodeMedArstall = (fomArg: any, tomArg: any) => {
-    const fom = new Date(fomArg)
-    const tom = new Date(tomArg)
+    const fom = parseLocalDate(fomArg)
+    const tom = parseLocalDate(tomArg)
     const erSammeAar = fom.getFullYear() === tom.getFullYear()
     const erSammeMaaned = fom.getMonth() === tom.getMonth()
     return erSammeAar && erSammeMaaned

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
     plugins: [react()],
+    envDir: '/tmp/vitest-env-dir',
     test: {
         exclude: ['**/node_modules/**', '**/playwright/**'],
         environment: 'jsdom',


### PR DESCRIPTION
## Problem

Dato-strenger (`"2021-02-08"`) blir parset som UTC-timestamp av `new Date()`, og tidssonen drar klokkeslettet bakover som endrer datoen.

**Konkret:** `new Date("2021-02-08")` tolkes som `2021-02-08T00:00:00Z` (UTC midnatt). Når JavaScript så kaller `.getDate()` i New York (UTC-5), konverterer den til lokal tid: `2021-02-07T19:00:00-05:00` → `.getDate()` returnerer **7**, ikke 8.

Vi har altså en **ren dato** som vi bare vil vise som dato, men `new Date()` legger på `T00:00:00Z` og gjør den til et UTC-tidspunkt. Deretter henter vi ut dag/måned/år i lokal tid — og da har tidssonen forskjøvet oss til "dagen før".

## Løsning

`parseLocalDate()` bruker `new Date(2021, 1, 8)` (constructor med tall) som alltid lager **lokal midnatt**, så `.getDate()` gir 8 uansett tidssone.

```typescript
function parseLocalDate(datoArg: Date | string): Date {
    if (datoArg instanceof Date) return datoArg
    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(datoArg))
    if (match) {
        return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
    }
    return new Date(String(datoArg))
}
```

Regex matcher kun dato-strenger (`YYYY-MM-DD`). Fulle timestamps med tid faller gjennom til vanlig `new Date()` som er korrekt for dem.

## Endringer

1. **Pek vitest envDir til tom mappe** — workaround for macOS EPERM på .env
2. **Parse datostrenger som lokal tid** — `parseLocalDate()` helper i dato-utils
3. **Bruk lokal tid i erHelg-tester** — testene var også sårbare
4. **Erstatt any-typer** — eksplisitte typer og norsk kommentar
5. **Playwright-test** — verifiserer datovisning i Europe/Oslo, America/New_York og UTC

## Sammenligning med ditt-sykefravaer

I [ditt-sykefravaer (09af785)](https://github.com/navikt/ditt-sykefravaer/commit/09af785) ble løsningen å innføre `@date-fns/tz` med `TZDate` og tvinge alle datoer til `Europe/Oslo`. Det er en tyngre løsning som passer der fordi ditt-sykefravaer allerede bruker `date-fns` tungt.

Her i spinnsyn-frontend bruker vi kun `dayjs` (som allerede parser dato-strenger som lokal tid) og enkel `new Date()` i dato-utils. Vår løsning er enklere og dependency-fri: vi parser `YYYY-MM-DD` som lokal midnatt i stedet for UTC midnatt. Effekten er den samme — datoen forskyves ikke.