### PR TITLE
Fiks manglende fixture-oppsett i tidssone-tester

### DIFF
--- a/playwright/fixtures.ts
+++ b/playwright/fixtures.ts
@@ -12,11 +12,11 @@ export const test = base.extend<{ uuOptions: UUOptions }>({
     uuOptions: [{ skipUU: false, disableRules: [] }, { option: true }],
 })
 
-test.beforeEach(async ({ context, page }) => {
+test.beforeEach(async ({ context }) => {
     await context.clearCookies()
 
     // Skjul dev-tools hint så de ikke er i veien for visuelle tester.
-    await page.addInitScript(() => {
+    await context.addInitScript(() => {
         window.localStorage.setItem('devtools-hint', 'false')
     })
 })

--- a/playwright/tidssone-datovisning.spec.ts
+++ b/playwright/tidssone-datovisning.spec.ts
@@ -1,15 +1,14 @@
-import { test as base, expect } from '@playwright/test'
-
 import { kunDirekte } from '../src/data/testdata/data/vedtak/kunDirekte'
+
+import { test, expect } from './fixtures'
 
 const timezones = ['Europe/Oslo', 'America/New_York', 'UTC']
 
 for (const timezoneId of timezones) {
-    base.describe(`Datovisning i tidssone ${timezoneId}`, () => {
-        base(`viser korrekte datoer på vedtakssiden`, async ({ browser }) => {
-            const context = await browser.newContext({ timezoneId })
-            const page = await context.newPage()
+    test.describe(`Datovisning i tidssone ${timezoneId}`, () => {
+        test.use({ timezoneId })
 
+        test(`viser korrekte datoer på vedtakssiden`, async ({ page }) => {
             await page.goto(`/syk/sykepenger?testperson=kun-direkte`)
             await expect(page.getByRole('link', { name: /Sykmeldt fra /i })).toHaveCount(1)
 
@@ -29,8 +28,6 @@ for (const timezoneId of timezones) {
             // Verifiser behandlingsdato (vedtakFattetTidspunkt: '2021-02-21')
             // Bruker tilLesbarDatoMedArstall via dayjs().toDate()
             await expect(page.getByText('Søknaden ble behandlet 21. februar 2021')).toBeVisible()
-
-            await context.close()
         })
     })
 }

--- a/src/components/person/Person.tsx
+++ b/src/components/person/Person.tsx
@@ -15,15 +15,12 @@ export default function Person() {
     }, [])
 
     useEffect(() => {
-        if (localStorage.getItem('devtools-hint') === null) {
-            localStorage.setItem('devtools-hint', 'true')
-        }
+        const value = localStorage.getItem('devtools-hint')
+        // Respekter eksplisitt 'false' (f.eks. satt av tester eller etter at hintet er avvist).
+        if (value === 'false') return
 
-        setTimeout(() => {
-            if (localStorage.getItem('devtools-hint') === 'true') {
-                setShowHint(true)
-            }
-        }, 1000)
+        const timer = setTimeout(() => setShowHint(true), 1000)
+        return () => clearTimeout(timer)
     }, [])
 
     return (


### PR DESCRIPTION
- Erstatt manuell browser.newContext() med test.use({ timezoneId }) slik at
Playwrights fixtures og beforeEach-hook kjører korrekt. Sikrer at
devtools-hint skjules og forhindrer at Popover blokkerer klikk på små skjermer.
- Respekter eksplisitt devtools-hint=false i Person
